### PR TITLE
Add setVerbosityForAddress for test cases

### DIFF
--- a/04-testing/test/step5.spec.ts
+++ b/04-testing/test/step5.spec.ts
@@ -26,6 +26,7 @@ describe("Counter tests", () => {
 
   it("should send ton coin to the contract", async () => {
     console.log("sending 7.123 TON");
+    await blockchain.setVerbosityForAddress(counterContract.address,"vm_logs");
     await wallet1.send({
       to: counterContract.address,
       value: toNano("7.123")
@@ -34,6 +35,7 @@ describe("Counter tests", () => {
 
   it("should increment the counter value", async () =>  {
     console.log("sending increment message");
+    await blockchain.setVerbosityForAddress(counterContract.address,"vm_logs");
     await counterContract.sendIncrement(wallet1.getSender());
   })
 });


### PR DESCRIPTION
Test cases doesn't print debug statements from counter.cell, but only console.log statements from step5.spec.ts @krigga from TONDevChat suggested this fix and it works, so I thought it would be nice to make a PR.