### PR TITLE
fix: Update 01-wallet index.md

### DIFF
--- a/01-wallet/index.md
+++ b/01-wallet/index.md
@@ -24,7 +24,7 @@ The point of blockchain is being in control of your own funds, so we'll naturall
 ---
 network:testnet
 ---
-Tonkeeper works by default on TON mainnet. If you decided to work on testnet, you will need to switch the app manually to dev mode. Open the "Settings" tab and tap 5 times quickly on the Version number on the bottom. The "Dev Menu" should show up. Click on "Switch to Testnet" and make the switch. You can use this menu later to return to mainnet.
+Tonkeeper works by default on TON mainnet. If you decided to work on testnet, you will need to switch the app manually to dev mode. Open the "Settings" tab and tap 5 times quickly on the Tonkeeper Logo on the bottom. The "Dev Menu" should show up. Click on "Switch to Testnet" and make the switch. You can use this menu later to return to mainnet.
 
 ---
 


### PR DESCRIPTION
I have checked the way to switch testnet with the Tonkeeper team. They said should click the logo not click the version number. I have tried it successfully by clicking the logo.