### PR TITLE
fix an "invalid address" error coming from client.open()

### DIFF
--- a/03-client/index.md
+++ b/03-client/index.md
@@ -209,7 +209,8 @@ import { useEffect, useState } from 'react';
 import Counter from '../contracts/counter';
 import { useTonClient } from './useTonClient';
 import { useAsyncInitialize } from './useAsyncInitialize';
-import { Address, OpenedContract } from '@ton/core';
+import { OpenedContract } from '@ton/core';
+import { Address } from '@ton/ton';
 
 export function useCounterContract() {
   const client = useTonClient();
@@ -327,7 +328,8 @@ import Counter from '../contracts/counter';
 import { useTonClient } from './useTonClient';
 import { useAsyncInitialize } from './useAsyncInitialize';
 import { useTonConnect } from './useTonConnect';
-import { Address, OpenedContract } from '@ton/core';
+import { OpenedContract } from '@ton/core';
+import { Address } from '@ton/ton';
 
 export function useCounterContract() {
   const client = useTonClient();


### PR DESCRIPTION
in the `03 tutorial` when `client.open()` is called I get an `Invalid address` error

![image](https://github.com/ton-community/tutorials/assets/94941/f50c220c-9142-4740-aaa0-2d9cf4bb6ff9)


After some debugging I realized that this is due to `Address.isAddress()` (in `ton-core`) using `instanceof` for determining that the given object is an address. The packing/bunding process of the code creates to a situation where there are two different `Address` classes at runtime, thereby making the `instanceof` check evaluate to `false`.

This was fixed by importing the `Address` class from `@ton/ton` (instead of `@ton/core`)



https://github.com/ton-core/ton-core/blob/main/src/contract/openContract.ts#L27
https://github.com/ton-core/ton-core/blob/main/src/address/Address.ts#L65