### PR TITLE
fixed the ES modules error by adding tsconfig.json

### DIFF
--- a/01-wallet/index.md
+++ b/01-wallet/index.md
@@ -125,6 +125,22 @@ Let's create a new directory for our project and support TypeScript. Open termin
 npm install ts-node
 ```
 
+We also need to add a configuration file. Create the file `tsconfig.json` with the following content:
+
+```
+   {
+     "compilerOptions": {
+       "module": "commonjs",
+       "esModuleInterop": true,
+       "target": "es6",
+       "moduleResolution": "node",
+       "sourceMap": true,
+       "outDir": "dist"
+     },
+     "lib": ["es2015"]
+   }
+```
+
 ---
 library:npmton
 ---

--- a/01-wallet/test/npmton/tsconfig.json
+++ b/01-wallet/test/npmton/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+      "module": "commonjs",
+      "esModuleInterop": true,
+      "target": "es6",
+      "moduleResolution": "node",
+      "sourceMap": true,
+      "outDir": "dist"
+    },
+    "lib": ["es2015"]
+  }

--- a/01-wallet/test/tonweb/tsconfig.json
+++ b/01-wallet/test/tonweb/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+      "module": "commonjs",
+      "esModuleInterop": true,
+      "target": "es6",
+      "moduleResolution": "node",
+      "sourceMap": true,
+      "outDir": "dist"
+    },
+    "lib": ["es2015"]
+  }


### PR DESCRIPTION
Lesson 1 tests started to fail. It seems to me the problem is a nodejs/ts-node update that requires ES modules support and is not backward compatible. It can be fixed by adding the `tsconfig.json` file. I've added it to the test directories and updated the tutorial accordingly.